### PR TITLE
Resolve lost devices after flash or config write

### DIFF
--- a/arch/arm/boot/dts/at91-sama5d3_xplained_dm_pda4.dtsi
+++ b/arch/arm/boot/dts/at91-sama5d3_xplained_dm_pda4.dtsi
@@ -70,7 +70,7 @@
 				atmel_mxt_ts@4a {
 					compatible = "atmel,atmel_mxt_ts";
 					reg = <0x4a>;
-					reset-gpios = <&pioE 8 GPIO_ACTIVE_LOW>;
+					reset-gpios = <&pioE 6 GPIO_ACTIVE_LOW>;
 					interrupt-parent = <&pioE>;
 					interrupts = <7 0x2>;	/* Falling edge only */
 					pinctrl-names = "default";


### PR DESCRIPTION
Removed mxt_free_input_device and mxt_free_object_table, not necessary after flashing device
Resolves lost input devices after flash
Removed mxt_initialize, not necessary to do full input device init
No longer removing input devices on fw or config flash.
Resolves input devices losing original input # in OS.