### PR TITLE
Enhance resync logic usage

### DIFF
--- a/arch/arm/boot/dts/at91-sama5d3_xplained_dm_pda4.dtsi
+++ b/arch/arm/boot/dts/at91-sama5d3_xplained_dm_pda4.dtsi
@@ -70,6 +70,7 @@
 				atmel_mxt_ts@4a {
 					compatible = "atmel,atmel_mxt_ts";
 					reg = <0x4a>;
+					resync-enabled;
 					reset-gpios = <&pioE 8 GPIO_ACTIVE_LOW>;
 					interrupt-parent = <&pioE>;
 					interrupts = <7 0x2>;	/* Falling edge only */
@@ -83,6 +84,7 @@
 				atmel_mxt_ts@4c {
 					compatible = "atmel,atmel_mxt_ts";
 					reg = <0x4c>;
+					resync-enabled;
 					interrupt-parent = <&pioE>;
 					interrupts = <6 0x2>;	/* Falling edge only */
 					pinctrl-names = "default";


### PR DESCRIPTION
Expand usage of resync logic to cover more scenarios of possible loss of sync between Host and Device
Removed clearing of infoblock table when resync logic is triggered to prevent crc_enabled flag returning incorrect state
Fixed incorrect check for CRC pass/fail on reads from config space