### PR TITLE
Add cfg_name property to skip cfg update on driver probe

### DIFF
--- a/arch/arm/boot/dts/at91-sama5d3_xplained_dm_pda4.dtsi
+++ b/arch/arm/boot/dts/at91-sama5d3_xplained_dm_pda4.dtsi
@@ -60,8 +60,19 @@
 				atmel_mxt_ts@4a {
 					compatible = "atmel,atmel_mxt_ts";
 					reg = <0x4a>;
+					reset-gpios = <&pioE 8 GPIO_ACTIVE_LOW>;
+					interrupt-parent = <&pioE>;
+					interrupts = <7 0x2>;	/* Falling edge only */
+					pinctrl-names = "default";
+					pinctrl-0 = <&pinctrl_mxt_irq1 &pinctrl_mxt_rst>;
+
 					resync-enabled;	/* Set if resync required */
-					xyswitch = <1>;
+
+					/* Uncomment to update config on driver probe */
+					atmel,cfg_name = "maxtouch.cfg";
+					
+					/* Customize if cfg is encrypted */
+					xyswitch = <1>; 
 					inverty = <1>;
 					invertx = <1>;
 					atmel,x-range = <1822>;
@@ -69,13 +80,7 @@
 					atmel,tch-aux = <0>;
 					atmel,xsize = <0>;
 					atmel,ysize = <0>;
-					reset-gpios = <&pioE 8 GPIO_ACTIVE_LOW>;
-					interrupt-parent = <&pioE>;
-					interrupts = <7 0x2>;	/* Falling edge only */
-					pinctrl-names = "default";
-					pinctrl-0 = <&pinctrl_mxt_irq1 &pinctrl_mxt_rst>;
 				};
-
 			};
 
 			hlcdc: hlcdc@f0030000 {


### PR DESCRIPTION
Add cfg_name property
Add atmel,cfg_name property to device tree file
If property not present, request_firmware_nowait() is bypassed to reduce boot delays