### PR TITLE
Remove fallthrough btldr address lookup

### DIFF
--- a/drivers/input/touchscreen/atmel_mxt_ts.c
+++ b/drivers/input/touchscreen/atmel_mxt_ts.c
@@ -16,7 +16,7 @@
  *
  */
 
-#define DRIVER_VERSION_NUMBER "4.19-20260506"
+#define DRIVER_VERSION_NUMBER "4.19-202600605"
 
 #include <linux/version.h>
 #include <linux/acpi.h>
@@ -1194,38 +1194,52 @@ static int mxt_bootloader_write(struct mxt_data *data,
 
 static int mxt_lookup_bootloader_address(struct mxt_data *data, bool retry)
 {
-	u8 appmode = data->client->addr;
-	u8 bootloader;
-	u8 family_id = data->info ? data->info->family_id : 0;
+	u8 bootloader = 0x4a;
+	u8 bootloader_offset;
+	u8 family_id;
+	u8 appmode;
+	int ret = 0;
+
+	family_id = (data->info != NULL) ? data->info->family_id : (u8)0;
+
+	if (data->client->addr > 0xFFU) {
+		dev_err(&data->client->dev,
+			"I2C address is too large 0x%04x\n", data->client->addr);
+		return -EINVAL;
+	}
+
+	appmode = (u8)data->client->addr;
+
+	// Determine the correct offset based on context
+	if (((appmode == 0x4aU) || (appmode == 0x4bU)) && (retry || (family_id >= 0xa2U))) {
+		bootloader_offset = 0x24U;
+	} else {
+		bootloader_offset = 0x26U;
+	}
 
 	switch (appmode) {
 	case 0x4a:
 	case 0x4b:
-		/* Chips after 1664S use different scheme */
-		if (retry || family_id >= 0xa2) {
-			bootloader = appmode - 0x24;
-			break;
-		}
-		/* Fall through for normal case */
 	case 0x4c:
 	case 0x4d:
 	case 0x5a:
 	case 0x5b:
-		bootloader = appmode - 0x26;
+		bootloader = appmode - bootloader_offset;
 		break;
 
 	default:
 		dev_err(&data->client->dev,
 			"Appmode i2c address 0x%02x not found\n",
 			appmode);
-		return -EINVAL;
+		ret = -EINVAL;
+		break;
 	}
 
 	data->bootloader_addr = bootloader;
 
 	dev_info(&data->client->dev, "Bootloader address: %x\n", bootloader);
 
-	return 0;
+	return ret;
 }
 
 static int mxt_probe_bootloader(struct mxt_data *data, bool alt_address)

--- a/drivers/input/touchscreen/atmel_mxt_ts.c
+++ b/drivers/input/touchscreen/atmel_mxt_ts.c
@@ -16,7 +16,7 @@
  *
  */
 
-#define DRIVER_VERSION_NUMBER "4.19-202600605"
+#define DRIVER_VERSION_NUMBER "4.19-20260605"
 
 #include <linux/version.h>
 #include <linux/acpi.h>


### PR DESCRIPTION
-- Remove fall-through in switch statement in mxt_lookup_bootloader_address()
-- Fixed due to possible compiler errors